### PR TITLE
Force grep command to use UTF-8 locale in solution for 'reorder' level

### DIFF
--- a/levels/changing-the-past/reorder
+++ b/levels/changing-the-past/reorder
@@ -71,7 +71,7 @@ git commit -am "Put on shirt"
 [win]
 
 # Reorder the commits to dress yourself in the correct way
-{ git log main --oneline | grep -Pz "shoes[\s\S]*pants[\s\S]*underwear"; } && { test "$(git log main --oneline | wc -l)" -eq 5; }
+{ git log main --oneline | LC_ALL=en_US.utf8 grep -Pz "shoes[\s\S]*pants[\s\S]*underwear"; } && { test "$(git log main --oneline | wc -l)" -eq 5; }
 
 [congrats]
 


### PR DESCRIPTION
Level **reorder** failed to complete in Windows build of Version 0.6.2 despite inputting correct solution. Issue turned out to be an error in the grep command with the following message:

`grep: -P supports only unibyte and UTF-8 locales`

Employing the solution from [this SO topic](https://stackoverflow.com/a/61457626) fixes the error and allows level to be completed successfully.