### PR TITLE
Simplify solution for level 'stash-merge' by adding recipe to index

### DIFF
--- a/levels/stash/stash-merge
+++ b/levels/stash/stash-merge
@@ -35,6 +35,7 @@ git stash push
 echo "- Pinch of Salt" >> recipe
 
 git checkout main
+git add recipe
 
 [win]
 


### PR DESCRIPTION
If recipe isn't part of index, user receives an error warning that local changes to file would be overwritten by merge when executing `git stash pop`. Since the focus of this lesson is learning about popping the stash, starting with recipe already added to index neatly sidesteps this error.