### PR TITLE
Fix deadlock in stash levels

### DIFF
--- a/scripts/net-test
+++ b/scripts/net-test
@@ -34,12 +34,12 @@ while(true) {
     STDOUT->flush();
 
     $s = "";
-    $command = $s2 . "\necho MAGIC\n";
+    $command = $s2 . "\necho -e \"\\v\"\n";
     print $in $command;
 
     inner_while: while (true) {
         $line = <$out>;
-        if ($line eq "MAGIC\n") {
+        if ($line =~ s/\cK//) {
             STDOUT->flush();
             last inner_while;
         }


### PR DESCRIPTION
`git stash` does not append a newline when rendering a commit subject.
This has the side-effect of causing the MAGIC terminator to appear
in-line with the results of cat-file -p calls against stash references.
The IPC client in net-test does not handle this gracefully and results
in a deadlock. Stash message newline behavior is inconsistent across
Windows, OSX, and Linux platforms.

Fix bug by eliminating dependency on MAGIC terminator. Using IPC::Open3
example from Programming Perl, Third Edition, change the following:
- open a new process for each command request from game
- close $in to give EOF to child process
- read from $out until EOF
- wait for child process to exit

Tested changes against all levels with win conditions.