### PR TITLE
Fix: gpgsign fails the commit

### DIFF
--- a/scripts/gitconfig
+++ b/scripts/gitconfig
@@ -12,3 +12,5 @@
 	detachedHead = false
 [receive]
 	denyCurrentBranch = ignore
+[commit]
+    gpgsign = false


### PR DESCRIPTION
Fixing the setup files where possible.

[fixes #62]

It is kind of a hack. Maybe a better way would be to make a `/git/config` file and use it in the git commands in the game...