### PR TITLE
fix-coffee-branch-incorrectly-drops-baguette

### DIFF
--- a/levels/changing-the-past/rebase
+++ b/levels/changing-the-past/rebase
@@ -38,7 +38,7 @@ git add .
 git commit -m "You eat the baguette"
 
 git checkout -b coffee
-echo "You do not have a baguette.
+echo "You ate a baguette.
 
 You have coffee.
 


### PR DESCRIPTION
It seems that the first commit int the `coffee` branch, drops the changes to the baguette line, causing a failing test in the end since either the baguette isn't eaten, or there are more than 7 commits in the rebased history.

This is an !!untested!! suggested fix.

Closes #65 