### PR TITLE
Fix rebase game

### DIFF
--- a/levels/changing-the-past/rebase
+++ b/levels/changing-the-past/rebase
@@ -37,7 +37,7 @@ You do not have a donut." > you
 git add .
 git commit -m "You eat the baguette"
 
-git checkout -b coffee
+git checkout -b coffee main
 echo "You do not have a baguette.
 
 You have coffee.


### PR DESCRIPTION
rebase does not appear solvable in 7 moves unless:

- `coffee` branches from `main` 
- `coffee` branches from `baguette` but does not erase `baguette` history.
- `coffee` branches from `baguette` but more than 7 commands are allowed to add & commit the missing baguette

Branching from main seems like the most likely intent for this game, giving three unique branches instead of coffee branching from baguette.

This resolves issue #65 