### PR TITLE
Use HOME env variable on Mac

### DIFF
--- a/scenes/helpers.gd
+++ b/scenes/helpers.gd
@@ -93,7 +93,7 @@ func careful_delete(path_inside):
 	if os == "X11":
 		expected_prefix = "/home/%s/.local/share/Oh My Git/tmp/" % OS.get_environment("USER")
 	elif os == "OSX":
-		expected_prefix = "/Users/%s/Library/Application Support/Oh My Git/tmp/" % OS.get_environment("USER")
+		expected_prefix = "%s/Library/Application Support/Oh My Git/tmp/" % OS.get_environment("HOME")
 	elif os == "Windows":
 		expected_prefix = "C:/Users/%s/AppData/Roaming/Oh My Git/tmp/" % OS.get_environment("USERNAME")
 		# Windows treats paths case-insensitively:


### PR DESCRIPTION
instead of trying to reconstruct it possibly incorrectly.

Fixes #60

--
Did this change blind but it seems reasonable.