### PR TITLE
Added info of the 'friend' repo, that the player needs to clone, in the level description.

### DIFF
--- a/levels/workflows/pr
+++ b/levels/workflows/pr
@@ -3,7 +3,8 @@ cards = clone commit-auto reset-hard checkout file-new branch
 
 [description]
 
-Your friend has a problem! Clone the repo, create a branch called "solution", and fix the problem in this branch. When you're ready, make a "Pull Request" by using `git tag pr`.
+Your friend has a problem! Clone the repo located in `../friend`, create a branch called "solution", and fix the problem in this branch. When you're ready, make a "Pull Request" by using `git tag pr`.
+
 
 [setup]
 


### PR DESCRIPTION
The level description/instructions weren't very clear as of where is the repo that needs to be cloned, unless you start dragging the "git clone" card and see highlighted the "friend" text, giving the player a hint.

This could be enough information for some players, but confusing for someone who is only using the terminal.