### PR TITLE
fake-editor: Prefix save message with an "s"

### DIFF
--- a/scenes/text_editor.gd
+++ b/scenes/text_editor.gd
@@ -38,7 +38,8 @@ func save():
 		if text.length() > 0 and text.substr(text.length()-1, 1) != "\n":
 			text += "\n"
 		
-		_client_connection.put_string(text)
+		# Prefix with an 's' to say that this is a "save", not a "close".
+		_client_connection.put_string("s" + text)
 		
 		emit_signal("saved")
 		close()

--- a/scripts/fake-editor
+++ b/scripts/fake-editor
@@ -28,10 +28,12 @@ my $new_content = "";
 $socket->recv($new_content, $length);
 
 # Write content back into the file.
-my $handle;
-open ($handle,'>',$absolute_path) or die("Error opening file");
-print $handle $new_content;
-close ($handle) or die ("Error closing file");
+if ($new_content =~ /^s/) {
+    my $handle;
+    open ($handle,'>',$absolute_path) or die("Error opening file");
+    print $handle (substr $new_content, 1);
+    close ($handle) or die ("Error closing file");
+}
 
 # This call is intended to block, we're waiting for Godot to close the connection.
 my $reply;


### PR DESCRIPTION
With this, we can distinguish "save" from "close"

This fixes issue #160