### PR TITLE
Clarify Godot requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you have ideas for new features, we'd be excited to hear them! Also in that c
 
 Wanna build your own level? Great! Here's how to do it:
 
-1. Download the latest version of the [Godot game engine](https://godotengine.org).
+1. Download the latest version of the [Godot **3** game engine](https://godotengine.org/download/3.x). Godot 4 is not supported yet.
 1. Clone this repository.
 1. Run the game – the easiest way to do so is to run `godot scenes/main.tscn` from the project directory.
 1. Get a bit familiar with the levels which are currently there.


### PR DESCRIPTION
At the moment, [the most recent commit to the main branch][1] was created before [Godot 4 was released][2]. When that commit was created, it was accurate to tell users to download the latest version of Godot because the latest version of Godot was a version of Godot 3. Now, that statement is no longer accurate because the latest version of Godot is a version of Godot 4, and Oh My Git! hasn’t been ported to Godot 4 yet.

It’s possible that we can just import Oh My Git! into Godot 4 and have it work fine, but that would require significant testing that I’m not going to do at the moment.

[1]: <https://github.com/git-learning-game/oh-my-git/commit/853b8e2d53c9c108920795bf0c3fea8f9baf554c>
[2]: <https://godotengine.org/article/godot-4-0-sets-sail/>