### PR TITLE
Fix win32 Busybox compat

### DIFF
--- a/scenes/shell.gd
+++ b/scenes/shell.gd
@@ -8,7 +8,7 @@ var _os = OS.get_name()
 
 func _init():
 	# Create required directories and move into the tmp directory.
-	_cwd = "/tmp"
+	_cwd = OS.get_user_data_dir() + "/tmp"
 	run("mkdir -p '%s/repos'" % game.tmp_prefix)
 	_cwd = game.tmp_prefix
 	


### PR DESCRIPTION
Greatly improves subprocess execution times. Just replace dependencies\windows\git\usr\bin\bash.exe with https://frippery.org/files/busybox/busybox.exe after merging.
