### PR TITLE
Update reflog: Grammar

### DIFF
--- a/levels/shit-happens/reflog
+++ b/levels/shit-happens/reflog
@@ -5,9 +5,9 @@ cards = checkout reflog
 
 Say you were looking at something in the past, and then switched back to the main branch.
 
-But then, you got reaaally distracted, and after your lunch break, you can't remember on which commit in the past you were before. How can you find out?
+But then, you got reaaally distracted, and after your lunch break, you can't remember which past commit you were on before. How can you find out?
 
-There's a convenient command that shows you all the places your HEAD did point to in the past:
+There's a convenient command that shows you all the places your HEAD has pointed to in the past:
 
     git reflog
 


### PR DESCRIPTION
This commit is comprised of three changes; two stylistic and one grammatical error fix:

1. change "commit in the past" to "past commit", which flows better in the sentence

2. change "on which past commit you were before" to "which past commit you were on before". While both sentences are grammatical, the former is likely to confuse the reader momentarily because the "on" has to take a long and unexpected journey to land in between "were" and "before".

3. "your HEAD did point to" to "your HEAD has pointed to". This changes the tense to present perfect, which is correct in this circumstance.

The commas in the description are technically ungrammatical, or would be judged so by some, but I like the tone they convey, so I left them.